### PR TITLE
Fix for authentication errors when additional params are in the parameters hash.

### DIFF
--- a/lib/mandrill-rails/web_hook_processor.rb
+++ b/lib/mandrill-rails/web_hook_processor.rb
@@ -83,7 +83,7 @@ module Mandrill::Rails::WebHookProcessor
   def authenticate_mandrill_request!
     expected_signature = request.headers['HTTP_X_MANDRILL_SIGNATURE']
     mandrill_webhook_keys = self.class.mandrill_webhook_keys
-    if Mandrill::WebHook::Processor.authentic?(expected_signature,mandrill_webhook_keys,request.original_url,request.params)
+    if Mandrill::WebHook::Processor.authentic?(expected_signature,mandrill_webhook_keys,request.original_url,request.request_parameters)
       true
     else
       head(:forbidden, :text => "Mandrill signature did not match.")

--- a/lib/mandrill/web_hook/processor.rb
+++ b/lib/mandrill/web_hook/processor.rb
@@ -52,7 +52,7 @@ class Mandrill::WebHook::Processor
     # Method described in docs: http://help.mandrill.com/entries/23704122-Authenticating-webhook-requests
     def generate_signature(webhook_key, original_url, params)
       signed_data = original_url.dup
-      params.except(:action, :controller).keys.sort.each do |key|
+      params.keys.sort.each do |key|
         signed_data << key
         signed_data << params[key]
       end

--- a/spec/mandrill-rails/web_hook_processor_spec.rb
+++ b/spec/mandrill-rails/web_hook_processor_spec.rb
@@ -104,7 +104,7 @@ describe Mandrill::Rails::WebHookProcessor do
     let(:request) { double() }
     before do
       request.stub(:original_url).and_return(original_url)
-      request.stub(:params).and_return(raw_params)
+      request.stub(:request_parameters).and_return(raw_params)
       request.stub(:headers).and_return(headers)
       processor_instance.request = request
       processor_instance.params = params


### PR DESCRIPTION
Use only the post parameters when calculating the signature for a request from Mandrill. Fix inspiration comes from issue on original repo (https://github.com/evendis/mandrill-rails/issues/11).

This fixes invalid signatures being calculated when additional params that rails adds are in the params hash (like controller, action, subdomain).
