### PR TITLE
Add metada method to event decorator

### DIFF
--- a/lib/mandrill/web_hook/event_decorator.rb
+++ b/lib/mandrill/web_hook/event_decorator.rb
@@ -42,6 +42,11 @@ class Mandrill::WebHook::EventDecorator < Hash
     msg['_version']
   end
 
+  # Returns, if pre-configured, the metadata.
+  def metadata
+    msg['metadata']||{}
+  end
+
   # Returns the reply-to ID.
   # Applicable events: inbound
   def in_reply_to


### PR DESCRIPTION
Hey there!

I do not have all knowledge  about Mandrill-API as well as webhook  responses.

But, looking at the mandril-rails gem, I missed the metadata method in the event_decorator. Ended up adding a monkey patch.

Was wondering, maybe  a simple method could be handy for everyone using this gem. 

Is it?

Thanks! 
