### PR TITLE
Replace from_email with sender

### DIFF
--- a/lib/mandrill/web_hook/event_decorator.rb
+++ b/lib/mandrill/web_hook/event_decorator.rb
@@ -68,7 +68,7 @@ class Mandrill::WebHook::EventDecorator < Hash
   # Returns the email (String) of the sender.
   # Applicable events: inbound
   def sender_email
-    msg['from_email']
+    msg['sender']
   end
 
   # Returns the subject user email address.


### PR DESCRIPTION
According to this documentation: http://help.mandrill.com/entries/58303976-Message-Event-Webhook-format

The 'from_email' is no longer supported at Mandrill.

I replaced the 'from_email' with 'sender'