### PR TITLE
Add another backup option for event_decorator.message_id

### DIFF
--- a/lib/mandrill/web_hook/event_decorator.rb
+++ b/lib/mandrill/web_hook/event_decorator.rb
@@ -54,7 +54,7 @@ class Mandrill::WebHook::EventDecorator < Hash
   # Inbound events: references 'Message-Id' header.
   # Send/Open/Click events: references '_id' message attribute.
   def message_id
-    headers['Message-Id'] || msg['_id']
+    headers['Message-Id'] || msg['_id'] || self['_id']
   end
 
   # Returns the Mandrill message version.


### PR DESCRIPTION
If the webhook 'msg' attribute does not include an '_id' (this happens on my server occasionally), then we can also read the message id from the actual payload object directly. You will see in the [format documentation](https://mandrill.zendesk.com/hc/en-us/articles/205583307-Message-Event-Webhook-format) that the '_id' field is supposed to be included in both the payload and also nested within the 'msg' field. (And yes, the '_id' refers the email sent, not some "event identifier", as clarified in the documentation.)