### PR TITLE
Temporary fix for empty headers array submitted

### DIFF
--- a/lib/mandrill/web_hook/event_decorator.rb
+++ b/lib/mandrill/web_hook/event_decorator.rb
@@ -84,7 +84,10 @@ class Mandrill::WebHook::EventDecorator < Hash
   # Returns the headers Hash.
   # Applicable events: inbound
   def headers
-    msg['headers']||{}
+    return {} if msg['headers'].nil? || msg['headers'].empty?
+    return msg['headers'].first if msg['headers'].is_a? Array
+
+    msg['headers']
   end
 
   # Returns the email (String) of the sender.


### PR DESCRIPTION
When there is NDR bounce message, some mail servers are sending empty headers, which cannot be normally parsed from Mandrill servers and the library is breaking because it is expecting headers to be hash rather than array.
