### PR TITLE
Resolve Rails 5 deprecation warnings for *_filter hooks.

### DIFF
--- a/lib/mandrill-rails/web_hook_processor.rb
+++ b/lib/mandrill-rails/web_hook_processor.rb
@@ -34,8 +34,8 @@ module Mandrill::Rails::WebHookProcessor
   extend ActiveSupport::Concern
 
   included do
-    skip_before_filter :verify_authenticity_token
-    before_filter :authenticate_mandrill_request!, :only => [:create]
+    skip_before_action :verify_authenticity_token
+    before_action :authenticate_mandrill_request!, :only => [:create]
   end
 
   module ClassMethods

--- a/mandrill-rails.gemspec
+++ b/mandrill-rails.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.version       = Mandrill::Rails::VERSION
 
-  spec.add_runtime_dependency "activesupport", ">= 3.0.3"
+  spec.add_runtime_dependency "activesupport", ">= 4.0.0"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/mandrill-rails/web_hook_processor_spec.rb
+++ b/spec/mandrill-rails/web_hook_processor_spec.rb
@@ -3,10 +3,10 @@ require 'spec_helper'
 class WebHookProcessorTestHarness
   # Mock some controller behaviour
   # TODO: we should probably start using a real controller harness for testing
-  def self.skip_before_filter(*args) ; @skip_before_filter_settings = args; end
-  def self.skip_before_filter_settings ; @skip_before_filter_settings; end
-  def self.before_filter(*args) ; @before_filter_settings = args ; end
-  def self.before_filter_settings ; @before_filter_settings; end
+  def self.skip_before_action(*args) ; @skip_before_action_settings = args; end
+  def self.skip_before_action_settings ; @skip_before_action_settings; end
+  def self.before_action(*args) ; @before_action_settings = args ; end
+  def self.before_action_settings ; @before_action_settings; end
   def head(*args) ; end
   attr_accessor :params, :request
 
@@ -22,15 +22,15 @@ describe Mandrill::Rails::WebHookProcessor do
     processor_class.on_unhandled_mandrill_events! nil
   end
 
-  describe "##skip_before_filter settings" do
-    subject { processor_class.skip_before_filter_settings }
+  describe "##skip_before_action settings" do
+    subject { processor_class.skip_before_action_settings }
     it "includes verify_authenticity_token" do
       expect(subject).to eql([:verify_authenticity_token])
     end
   end
 
-  describe "##before_filter settings" do
-    subject { processor_class.before_filter_settings }
+  describe "##before_action settings" do
+    subject { processor_class.before_action_settings }
     it "includes authenticate_mandrill_request" do
       expect(subject).to eql([:authenticate_mandrill_request!, {:only=>[:create]}])
     end


### PR DESCRIPTION
In Rails 4.0.0 (2012) DHH renamed the `*_filter` hooks in
`AbstractController` to `*_action`. In Rails 5.0 it now prints
deprecation warnings for `*_filter` calls as they will be removed
in Rails 5.1.
